### PR TITLE
Added DisableAlerts Feature

### DIFF
--- a/src/formio.common.ts
+++ b/src/formio.common.ts
@@ -74,6 +74,7 @@ export interface FormioHookOptions {
 export interface FormioOptions {
   errors?: ErrorsOptions;
   alerts?: AlertsOptions;
+  disableAlerts?: boolean;
   i18n?: object;
   fileService?: object;
   hooks?: FormioHookOptions;

--- a/src/formio.component.ts
+++ b/src/formio.component.ts
@@ -33,7 +33,7 @@ const _isEmpty = require('lodash/isEmpty');
   template:
     '<div>' +
     '<formio-loader></formio-loader>' +
-    '<formio-alerts></formio-alerts>' +
+    '<formio-alerts *ngIf="!this.options.disableAlerts"></formio-alerts>' +
     '<div #formio></div>' +
     '</div>',
   styles: [require('./formio.component.scss').toString()],
@@ -156,6 +156,7 @@ export class FormioComponent implements OnInit, OnChanges {
         alerts: {
           submitMessage: 'Submission Complete.'
         },
+        disableAlerts: false,
         hooks: {
           beforeSubmit: null
         }


### PR DESCRIPTION
Angular 4 Render now has a variable defined in the src/formio.component.ts under this.options that allows users to turn on and off form submission alerts for their project. 