### PR TITLE
(FIX): Unique Validation Error on Alerts

### DIFF
--- a/src/components/formio/formio.component.ts
+++ b/src/components/formio/formio.component.ts
@@ -314,7 +314,7 @@ export class FormioComponent implements OnInit, OnChanges {
     each(err, (error: any) => {
       let message = '';
       if (!error.message) {
-        error.details.forEach(function (e) {
+        error.details.forEach((e) => {
           message = e.message + ' ';
         });
       }

--- a/src/components/formio/formio.component.ts
+++ b/src/components/formio/formio.component.ts
@@ -312,9 +312,15 @@ export class FormioComponent implements OnInit, OnChanges {
 
     // Iterate through each one and set the alerts array.
     each(err, (error: any) => {
+      let message = '';
+      if (!error.message) {
+        error.details.forEach(function (e) {
+          message = e.message + ' ';
+        });
+      }
       this.alerts.addAlert({
         type: 'danger',
-        message: error.message || error.toString()
+        message: message
       });
     });
   }


### PR DESCRIPTION
## Change
Add a for each in a validation message to get the Error message from details property.

## Reason 
Unique Validations doesn't have message property. The message property is in details array on the error instance.