### PR TITLE
(Fix): Conditionals in Error Alerts

### DIFF
--- a/src/components/formio/formio.component.ts
+++ b/src/components/formio/formio.component.ts
@@ -317,6 +317,8 @@ export class FormioComponent implements OnInit, OnChanges {
         error.details.forEach((e) => {
           message = e.message + ' ';
         });
+      } else {
+        message = error.message;
       }
       this.alerts.addAlert({
         type: 'danger',


### PR DESCRIPTION
### Reason
IF conditional doesn't check for the error.message property.