### PR TITLE
Skip early attempts to set grid footer createText.

### DIFF
--- a/src/grid/grid.component.ts
+++ b/src/grid/grid.component.ts
@@ -128,7 +128,8 @@ export class FormioGridComponent implements OnChanges, OnInit, AfterViewInit {
       this.loadGrid(changes.src.currentValue);
     }
 
-    if (changes.createText && changes.createText.currentValue) {
+    if (this.footer &&
+        (changes.createText && changes.createText.currentValue)) {
       this.footer.createText = changes.createText.currentValue;
     }
   }


### PR DESCRIPTION
Pull request for issue #270.

Fixes JavaScript error when using `<formio-grid createText="...">`.
