### PR TITLE
Tested changes.hideComponents.currentValue

### DIFF
--- a/src/FormioBaseComponent.ts
+++ b/src/FormioBaseComponent.ts
@@ -270,7 +270,7 @@ export class FormioBaseComponent implements OnInit, OnChanges, OnDestroy {
         this.formio.submission = changes.submission.currentValue;
       }
 
-      if (changes.hideComponents) {
+      if (changes.hideComponents  && changes.hideComponents.currentValue) {
         this.formio.hideComponents(changes.hideComponents.currentValue);
       }
     });


### PR DESCRIPTION
Avoid error message when currentValue is undefined.

I had to edit this manually, because I could not build with npm:build without thousands of peer dependency errors (No name was provided for external module).

Any link how to build the package would be helpful.