### PR TITLE
Performance: Run formio outside of ngZone

### DIFF
--- a/src/components/formio/formio.component.html
+++ b/src/components/formio/formio.component.html
@@ -1,5 +1,5 @@
 <div>
-  <div *ngIf="loader.loading" style="position:relative;height:200px">
+  <div *ngIf="loader.loading$ | async" style="position:relative;height:200px">
     <formio-loader></formio-loader>
   </div>
   <formio-alerts *ngIf="!this.options?.disableAlerts" [alerts]="alerts"></formio-alerts>

--- a/src/components/formio/formio.component.ts
+++ b/src/components/formio/formio.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, Optional, ViewEncapsulation, Input } from '@angular/core';
+import { Component, OnInit, Optional, ViewEncapsulation, Input, NgZone } from '@angular/core';
 import { FormioLoader } from '../loader/formio.loader';
 import { FormioAppConfig } from '../../formio.config';
 import { Formio, Form, Utils } from 'formiojs';
@@ -16,11 +16,12 @@ import { CustomTagsService } from '../../custom-component/custom-tags.service';
 export class FormioComponent extends FormioBaseComponent implements OnInit {
   @Input() noeval ? = false;
   constructor(
+    public ngZone: NgZone,
     public loader: FormioLoader,
     @Optional() public config: FormioAppConfig,
     @Optional() public customTags?: CustomTagsService,
   ) {
-    super(loader, config, customTags);
+    super(ngZone, loader, config, customTags);
     if (this.config) {
       Formio.setBaseUrl(this.config.apiUrl);
       Formio.setProjectUrl(this.config.appUrl);

--- a/src/components/loader/formio.loader.ts
+++ b/src/components/loader/formio.loader.ts
@@ -1,7 +1,14 @@
 import { Injectable } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
 
 @Injectable()
 export class FormioLoader {
+  public loading$ = new BehaviorSubject(true);
   public loading = true;
+
+  setLoading(loading: boolean) {
+    this.loading = loading;
+    this.loading$.next(loading);
+  }
 }
 


### PR DESCRIPTION
Angular runs inside NgZone which counts the microtasks and runs change detection when needed. However the external JavaScript libs should run outside of the zone not to give extra work to Angular.
https://angular.io/api/core/NgZone

This PR adds abilities to run formio outside of the zone and run the events back in the zone.

Breaking Changes:
- `NgZone` service is required for the components.
- The `FormioLoader` service is updated. The `loading` flag is also available as Observable, so we can use the `async` pipe in the template which takes care of the change detection properly.