### PR TITLE
Explicit field options for custom components

### DIFF
--- a/src/custom-component/create-custom-component.ts
+++ b/src/custom-component/create-custom-component.ts
@@ -1,6 +1,6 @@
 import { BuilderInfo, Components, ExtendedComponentSchema, Utils as FormioUtils } from 'formiojs';
 import { FormioCustomComponentInfo, FormioCustomElement } from '../formio.common';
-import { clone, isNil } from 'lodash';
+import { clone, isNil, isArray } from 'lodash';
 
 const BaseInputComponent = Components.components.input;
 const TextfieldComponent = Components.components.textfield;
@@ -114,6 +114,13 @@ export function createCustomFormioComponent(customComponentOptions: FormioCustom
         for (const key in this.component.validate) {
           if (this.component.validate.hasOwnProperty(key)) {
             this._customAngularElement[key] = this.component.validate[key];
+          }
+        }
+        if (isArray(customComponentOptions.fieldOptions) && customComponentOptions.fieldOptions.length > 0) {
+          for (const key in customComponentOptions.fieldOptions) {
+            if (this.component.validate.hasOwnProperty(key)) {
+              this._customAngularElement[key] = this.component.validate[key];
+            }
           }
         }
 

--- a/src/formio.common.ts
+++ b/src/formio.common.ts
@@ -78,6 +78,7 @@ export interface FormioCustomComponentInfo extends BuilderInfo {
   selector: string;
   emptyValue?: any;
   extraValidators?: (keyof ValidateOptions)[];
+  fieldOptions?: string[];
   template?: string;
   changeEvent?: string // Default: valueChange
   editForm?: () => { components: ExtendedComponentSchema[] };


### PR DESCRIPTION
Add an option to use the field options inside custom components.

Usage:
`fieldOptions: ['myOption']`

Example:
```js
const COMPONENT_OPTIONS: FormioCustomComponentInfo = {
  type: 'radiobuttons',
  selector: 'radio-buttons',
  title: 'Radio Buttons',
  group: 'basic', 
  icon: 'fa fa-star', 
  fieldOptions: ['values'],
  editForm: RadioButtonsForm,
}
```

Closes https://github.com/formio/angular-formio/issues/409